### PR TITLE
update faster version

### DIFF
--- a/auto-mask-fast.py
+++ b/auto-mask-fast.py
@@ -1,0 +1,574 @@
+import os
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+from PIL import Image
+from tqdm import tqdm
+from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
+import cv2
+import argparse
+from loguru import logger
+
+# use bfloat16 for the entire notebook
+torch.autocast(device_type="cuda", dtype=torch.bfloat16).__enter__()
+
+if torch.cuda.get_device_properties(0).major >= 8:
+    # turn on tfloat32 for Ampere GPUs (https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices)
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+
+from sam2.build_sam import build_sam2_video_predictor, build_sam2
+from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
+
+
+
+
+def show_anns(anns, borders=True):
+    if len(anns) == 0:
+        return
+    sorted_anns = sorted(anns, key=(lambda x: x['area']), reverse=True)
+    ax = plt.gca()
+    ax.set_autoscale_on(False)
+
+    img = np.ones((sorted_anns[0]['segmentation'].shape[0], sorted_anns[0]['segmentation'].shape[1], 4))
+    img[:,:,3] = 0
+    for ann in sorted_anns:
+        m = ann['segmentation']
+        color_mask = np.concatenate([np.random.random(3), [0.5]])
+        img[m] = color_mask 
+        if borders:
+            import cv2
+            contours, _ = cv2.findContours(m.astype(np.uint8),cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE) 
+            # Try to smooth contours
+            contours = [cv2.approxPolyDP(contour, epsilon=0.01, closed=True) for contour in contours]
+            cv2.drawContours(img, contours, -1, (0,0,1,0.4), thickness=1) 
+
+    ax.imshow(img)
+
+def mask_nms(masks, scores, iou_thr=0.7, score_thr=0.1, inner_thr=0.2, **kwargs):
+    """
+    Perform mask non-maximum suppression (NMS) on a set of masks based on their scores.
+    
+    Args:
+        masks (torch.Tensor): has shape (num_masks, H, W)
+        scores (torch.Tensor): The scores of the masks, has shape (num_masks,)
+        iou_thr (float, optional): The threshold for IoU.
+        score_thr (float, optional): The threshold for the mask scores.
+        inner_thr (float, optional): The threshold for the overlap rate.
+        **kwargs: Additional keyword arguments.
+    Returns:
+        selected_idx (torch.Tensor): A tensor representing the selected indices of the masks after NMS.
+    """
+
+    scores, idx = scores.sort(0, descending=True)
+    num_masks = idx.shape[0]
+    
+    masks_ord = masks[idx.view(-1), :]
+    masks_area = torch.sum(masks_ord, dim=(1, 2), dtype=torch.float)
+
+    iou_matrix = torch.zeros((num_masks,) * 2, dtype=torch.float, device=masks.device)
+    inner_iou_matrix = torch.zeros((num_masks,) * 2, dtype=torch.float, device=masks.device)
+    
+    for i in range(num_masks):
+        for j in range(i, num_masks):
+            intersection = torch.sum(torch.logical_and(masks_ord[i], masks_ord[j]), dtype=torch.float)
+            union = torch.sum(torch.logical_or(masks_ord[i], masks_ord[j]), dtype=torch.float)
+            iou = intersection / union
+            iou_matrix[i, j] = iou
+            # select mask pairs that may have a severe internal relationship
+            if intersection / masks_area[i] < 0.5 and intersection / masks_area[j] >= 0.85:
+                inner_iou = 1 - (intersection / masks_area[j]) * (intersection / masks_area[i])
+                inner_iou_matrix[i, j] = inner_iou
+
+            if intersection / masks_area[i] >= 0.85 and intersection / masks_area[j] < 0.5:
+                inner_iou = 1 - (intersection / masks_area[j]) * (intersection / masks_area[i])
+                inner_iou_matrix[j, i] = inner_iou
+
+    iou_matrix.triu_(diagonal=1)
+    iou_max, _ = iou_matrix.max(dim=0)
+    inner_iou_matrix_u = torch.triu(inner_iou_matrix, diagonal=1)
+    inner_iou_max_u, _ = inner_iou_matrix_u.max(dim=0)
+    inner_iou_matrix_l = torch.tril(inner_iou_matrix, diagonal=1)
+    inner_iou_max_l, _ = inner_iou_matrix_l.max(dim=0)
+    
+    keep = iou_max <= iou_thr
+    keep_conf = scores > score_thr
+    keep_inner_u = inner_iou_max_u <= 1 - inner_thr
+    keep_inner_l = inner_iou_max_l <= 1 - inner_thr
+    
+    # If there are no masks with scores above threshold, the top 3 masks are selected
+    if keep_conf.sum() == 0:
+        index = scores.topk(3).indices
+        keep_conf[index, 0] = True
+    if keep_inner_u.sum() == 0:
+        index = scores.topk(3).indices
+        keep_inner_u[index, 0] = True
+    if keep_inner_l.sum() == 0:
+        index = scores.topk(3).indices
+        keep_inner_l[index, 0] = True
+    keep *= keep_conf
+    keep *= keep_inner_u
+    keep *= keep_inner_l
+
+    selected_idx = idx[keep]
+    # import ipdb; ipdb.set_trace()
+    return selected_idx
+
+def filter(keep: torch.Tensor, masks_result) -> None:
+    keep = keep.int().cpu().numpy()
+    result_keep = []
+    for i, m in enumerate(masks_result):
+        if i in keep: result_keep.append(m)
+    return result_keep
+
+def masks_update(*args, **kwargs):
+    # remove redundant masks based on the scores and overlap rate between masks
+    masks_new = ()
+    for masks_lvl in (args):
+        seg_pred =  torch.from_numpy(np.stack([m['segmentation'] for m in masks_lvl], axis=0))
+        iou_pred = torch.from_numpy(np.stack([m['predicted_iou'] for m in masks_lvl], axis=0))
+        stability = torch.from_numpy(np.stack([m['stability_score'] for m in masks_lvl], axis=0))
+
+        scores = stability * iou_pred
+        keep_mask_nms = mask_nms(seg_pred, scores, **kwargs)
+        masks_lvl = filter(keep_mask_nms, masks_lvl)
+
+        masks_new += (masks_lvl,)
+    return masks_new
+
+def show_mask(mask, ax, obj_id=None, random_color=False):
+    if random_color:
+        color = np.concatenate([np.random.random(3), np.array([0.6])], axis=0)
+    else:
+        cmap = plt.get_cmap("tab20")
+        cmap_idx = 0 if obj_id is None else obj_id
+        color = np.array([*cmap(cmap_idx)[:3], 0.6])
+    h, w = mask.shape[-2:]
+    mask_image = mask.reshape(h, w, 1) * color.reshape(1, 1, -1)
+    ax.imshow(mask_image)
+
+def save_mask(mask,frame_idx,save_dir):
+    image_array = (mask * 255).astype(np.uint8)
+    # 创建图像对象
+    image = Image.fromarray(image_array[0])
+
+    # 保存图像
+    image.save(os.path.join(save_dir,f'{frame_idx:03}.png'))
+
+def save_masks(mask_list,frame_idx,save_dir):
+    os.makedirs(save_dir,exist_ok=True)
+    if len(mask_list[0].shape) == 3:
+        # 计算拼接图片的尺寸
+        total_width = mask_list[0].shape[2] * len(mask_list)
+        max_height = mask_list[0].shape[1]
+        # 创建大图片
+        final_image = Image.new('RGB', (total_width, max_height))
+        for i, img in enumerate(mask_list):
+            img = Image.fromarray((img[0] * 255).astype(np.uint8)).convert("RGB")
+            final_image.paste(img, (i * img.width, 0))
+        final_image.save(os.path.join(save_dir,f"mask_{frame_idx:03}.png"))
+    else:
+        # 计算拼接图片的尺寸
+        total_width = mask_list[0].shape[1] * len(mask_list)
+        max_height = mask_list[0].shape[0]
+        # 创建大图片
+        final_image = Image.new('RGB', (total_width, max_height))
+        for i, img in enumerate(mask_list):
+            img = Image.fromarray((img * 255).astype(np.uint8)).convert("RGB")
+            final_image.paste(img, (i * img.width, 0))
+        final_image.save(os.path.join(save_dir,f"mask_{frame_idx:03}.png"))
+
+def save_masks_npy(mask_list,frame_idx,save_dir):
+    np.save(os.path.join(save_dir,f"mask_{frame_idx:03}.npy"),np.array(mask_list))
+    
+def show_points(coords, labels, ax, marker_size=200):
+    pos_points = coords[labels==1]
+    neg_points = coords[labels==0]
+    ax.scatter(pos_points[:, 0], pos_points[:, 1], color='green', marker='*', s=marker_size, edgecolor='white', linewidth=1.25)
+    ax.scatter(neg_points[:, 0], neg_points[:, 1], color='red', marker='*', s=marker_size, edgecolor='white', linewidth=1.25)  
+
+def make_enlarge_bbox(origin_bbox, max_width,max_height,ratio):
+    width = origin_bbox[2]
+    height = origin_bbox[3]
+    new_box = [max(origin_bbox[0]-width*(ratio-1)/2,0),max(origin_bbox[1]-height*(ratio-1)/2,0)]
+    new_box.append(min(width*ratio,max_width-new_box[0]))
+    new_box.append(min(height*ratio,max_height-new_box[1]))
+    return new_box
+
+def sample_points(masks, enlarge_bbox,positive_num=1,negtive_num=40):
+    ex, ey, ewidth, eheight = enlarge_bbox
+    positive_count = positive_num
+    negtive_count = negtive_num
+    output_points = []
+    while True:
+        x = int(np.random.uniform(ex, ex + ewidth))
+        y = int(np.random.uniform(ey, ey + eheight))
+        if masks[y][x]==True and positive_count>0:
+            output_points.append((x,y,1))
+            positive_count-=1
+        elif masks[y][x]==False and negtive_count>0:
+            output_points.append((x,y,0))
+            negtive_count-=1
+        if positive_count == 0 and negtive_count == 0:
+            break
+
+    return output_points
+
+def sample_points_from_mask(mask):
+    # 获取所有True值的索引
+    true_indices = np.argwhere(mask)
+
+    # 检查是否存在True值
+    if true_indices.size == 0:
+        raise ValueError("The mask does not contain any True values.")
+
+    # 从True值索引中随机抽取一个点
+    random_index = np.random.choice(len(true_indices))
+    sample_point = true_indices[random_index]
+
+    return tuple(sample_point)
+
+
+def search_new_obj(masks_from_prev, mask_list,other_masks_list=None,mask_ratio_thresh=0,ratio=0.5, area_threash = 5000):
+    new_mask_list = []
+
+    # 计算mask_none，表示不包含在任何一个之前的mask中的区域
+    mask_none = ~masks_from_prev[0].copy()[0]
+    for prev_mask in masks_from_prev[1:]:
+        mask_none &= ~prev_mask[0]
+
+    for mask in mask_list:
+        seg = mask['segmentation']
+        if (mask_none & seg).sum()/seg.sum() > ratio and seg.sum() > area_threash:
+            new_mask_list.append(mask)
+    
+    for mask in new_mask_list:
+        mask_none &= ~mask['segmentation']
+    logger.info(len(new_mask_list))
+    # import ipdb; ipdb.set_trace()
+    logger.info("now ratio:",mask_none.sum() / (mask_none.shape[0] * mask_none.shape[1]) )
+    logger.info("expected ratios:",mask_ratio_thresh)
+    if other_masks_list is not None:
+        for mask in other_masks_list:
+            if mask_none.sum() / (mask_none.shape[0] * mask_none.shape[1]) > mask_ratio_thresh: # 还有很多的空隙，大于当前 thresh
+                seg = mask['segmentation']
+                if (mask_none & seg).sum()/seg.sum() > ratio and seg.sum() > area_threash:
+                    new_mask_list.append(mask)
+                    mask_none &= ~seg
+            else:
+                break
+    logger.info(len(new_mask_list))
+
+    return new_mask_list
+
+def get_bbox_from_mask(mask):
+    # 获取非零元素的行列索引
+    rows = np.any(mask, axis=1)
+    cols = np.any(mask, axis=0)
+    
+    # 找到非零行和列的最小和最大索引
+    ymin, ymax = np.where(rows)[0][[0, -1]]
+    xmin, xmax = np.where(cols)[0][[0, -1]]
+    
+    # 计算宽度和高度
+    width = xmax - xmin + 1
+    height = ymax - ymin + 1
+    
+    return xmin, ymin, width, height
+
+def cal_no_mask_area_ratio(out_mask_list):
+    h = out_mask_list[0].shape[1]
+    w = out_mask_list[0].shape[2]
+    mask_none = ~out_mask_list[0].copy()
+    for prev_mask in out_mask_list[1:]:
+        mask_none &= ~prev_mask
+    return(mask_none.sum() / (h * w))
+
+
+class Prompts:
+    def __init__(self,bs:int):
+        self.batch_size = bs
+        self.prompts = {}
+        self.obj_list = []
+        self.key_frame_list = []
+        self.key_frame_obj_begin_list = []
+
+    def add(self,obj_id,frame_id,mask):
+        if obj_id not in self.obj_list:
+            new_obj = True
+            self.prompts[obj_id] = []
+            self.obj_list.append(obj_id)
+        else:
+            new_obj = False
+        self.prompts[obj_id].append((frame_id,mask))
+        if frame_id not in self.key_frame_list and new_obj:
+            # import ipdb; ipdb.set_trace()
+            self.key_frame_list.append(frame_id)
+            self.key_frame_obj_begin_list.append(obj_id)
+            logger.info("key_frame_obj_begin_list:",self.key_frame_obj_begin_list)
+    
+    def get_obj_num(self):
+        return len(self.obj_list)
+    
+    def __len__(self):
+        if self.obj_list % self.batch_size == 0:
+            return len(self.obj_list) // self.batch_size
+        else:
+            return len(self.obj_list) // self.batch_size +1
+    
+    def __iter__(self):
+        # self.batch_index = 0
+        self.start_idx = 0
+        self.iter_frameindex = 0
+        return self
+
+    def __next__(self):
+        if self.start_idx < len(self.obj_list):
+            if self.iter_frameindex == len(self.key_frame_list)-1:
+                end_idx = min(self.start_idx+self.batch_size, len(self.obj_list))
+            else:
+                if self.start_idx+self.batch_size < self.key_frame_obj_begin_list[self.iter_frameindex+1]:
+                    end_idx = self.start_idx+self.batch_size
+                else:
+                    end_idx =  self.key_frame_obj_begin_list[self.iter_frameindex+1]
+                    self.iter_frameindex+=1
+                # end_idx = min(self.start_idx+self.batch_size, self.key_frame_obj_begin_list[self.iter_frameindex+1])
+            batch_keys = self.obj_list[self.start_idx:end_idx]
+            batch_prompts = {key: self.prompts[key] for key in batch_keys}
+            self.start_idx = end_idx
+            return batch_prompts
+        # if self.batch_index * self.batch_size < len(self.obj_list):
+        #     start_idx = self.batch_index * self.batch_size
+        #     end_idx = min(start_idx + self.batch_size, len(self.obj_list))
+        #     batch_keys = self.obj_list[start_idx:end_idx]
+        #     batch_prompts = {key: self.prompts[key] for key in batch_keys}
+        #     self.batch_index += 1
+        #     return batch_prompts
+        else:
+            raise StopIteration
+        
+def get_video_segments(prompts_loader,predictor,inference_state,step,start_frame_idx,final_output=False):
+    video_segments = {}
+    for batch_prompts in tqdm(prompts_loader,desc="processing prompts\n"):
+        predictor.reset_state(inference_state)
+        for id, prompt_list in batch_prompts.items():
+            for prompt in prompt_list:
+                # import ipdb; ipdb.set_trace()
+                _, out_obj_ids, out_mask_logits = predictor.add_new_mask(
+                    inference_state=inference_state,
+                    frame_idx=prompt[0],
+                    obj_id=id,
+                    mask=prompt[1]
+                )
+        # start_frame_idx = 0 if final_output else None
+        if not final_output:
+            for out_frame_idx, out_obj_ids, out_mask_logits in predictor.propagate_in_video(inference_state, max_frame_num_to_track=step, start_frame_idx=start_frame_idx):
+                if out_frame_idx not in video_segments:
+                    video_segments[out_frame_idx] = { }
+                for i, out_obj_id in enumerate(out_obj_ids):
+                    video_segments[out_frame_idx][out_obj_id]= (out_mask_logits[i] > 0.0).cpu().numpy()
+        
+        else:
+            for out_frame_idx, out_obj_ids, out_mask_logits in predictor.propagate_in_video(inference_state):
+                if out_frame_idx not in video_segments:
+                    video_segments[out_frame_idx] = { }
+                for i, out_obj_id in enumerate(out_obj_ids):
+                    video_segments[out_frame_idx][out_obj_id]= (out_mask_logits[i] > 0.0).cpu().numpy()
+            for out_frame_idx, out_obj_ids, out_mask_logits in predictor.propagate_in_video(inference_state,reverse=True):
+                for i, out_obj_id in enumerate(out_obj_ids):
+                    video_segments[out_frame_idx][out_obj_id]= (out_mask_logits[i] > 0.0).cpu().numpy()
+    return video_segments
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--video_path",type=str,required=True)
+    parser.add_argument("--output_dir",type=str,required=True)
+    parser.add_argument("--level",choices=['default','small','middle','large'])
+    parser.add_argument("--batch_size",type=int,default=20)
+    parser.add_argument("--detect_stride",type=int,default=10)
+    parser.add_argument("--use_other_level",type=int,default=1)
+    parser.add_argument("--postnms",type=int,default=1)
+    parser.add_argument("--pred_iou_thresh",type=float,default=0.7)
+    parser.add_argument("--box_nms_thresh",type=float,default=0.7)
+    parser.add_argument("--stability_score_thresh",type=float,default=0.85)
+    args = parser.parse_args()
+    logger.add(os.path.join(args.output_dir,f'{args.level}.log'), rotation="500 MB")
+    logger.info(args)
+    video_dir = args.video_path
+    level = args.level
+    base_dir = args.output_dir
+
+    ##### load Sam2 and Sam1 Model #####
+    sam2_checkpoint = "./checkpoints/sam2/sam2_hiera_large.pt"
+    model_cfg = "sam2_hiera_l.yaml"
+
+    predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint)
+
+    sam2 = build_sam2(model_cfg, sam2_checkpoint, device ='cuda', apply_postprocessing=False)
+
+    sam_ckpt_path="checkpoints/sam1/sam_vit_h_4b8939.pth"
+    sam = sam_model_registry["vit_h"](checkpoint=sam_ckpt_path).to('cuda')
+    mask_generator = SamAutomaticMaskGenerator(
+        model=sam,
+        points_per_side=32,
+        pred_iou_thresh=args.pred_iou_thresh, 
+        box_nms_thresh=args.box_nms_thresh, 
+        stability_score_thresh=args.stability_score_thresh, 
+        crop_n_layers=1,
+        crop_n_points_downscale_factor=1,
+        min_mask_region_area=100,
+    )
+    # scan all the JPEG frame names in this directory
+    frame_names = [
+        p for p in os.listdir(video_dir)
+        if os.path.splitext(p)[-1] in [".jpg", ".jpeg", ".JPG", ".JPEG"]
+    ]
+    frame_names.sort(key=lambda p: int(os.path.splitext(p)[0]))
+
+
+    now_frame = 0
+    inference_state = predictor.init_state(video_path=video_dir)
+    masks_from_prev = []
+    sum_id = 0 # 记录一共有多少个物体
+    is_key_frame = True # frame 0 is key frame (whether use sam)
+
+    prompts_loader = Prompts(bs=args.batch_size)  # hold all the clicks we add for visualization
+    for now_frame in range(0, len(frame_names), args.detect_stride):
+        logger.info(f"frame: {now_frame}")
+        logger.info(f"is_key_frame: {is_key_frame}")
+
+        if is_key_frame:
+            sum_id = prompts_loader.get_obj_num()
+            image_path = os.path.join(video_dir,frame_names[now_frame])
+            image = cv2.imread(image_path)
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            masks_default, masks_s, masks_m, masks_l = mask_generator.generate(image)
+            if args.postnms:
+                masks_default, masks_s, masks_m, masks_l = \
+                    masks_update(masks_default, masks_s, masks_m, masks_l, iou_thr=0.8, score_thr=0.7, inner_thr=0.5)
+            if level == 'default':
+                masks = [mask for mask in masks_default]
+                other_masks = [mask for mask in masks_l] + [mask for mask in masks_m] + [mask for mask in masks_s] 
+            elif level == 'small':
+                masks = [mask for mask in masks_s]
+                other_masks = None
+            elif level == 'middle':
+                masks = [mask for mask in masks_m]
+                other_masks = [mask for mask in masks_s]
+            elif level == 'large':
+                masks = [mask for mask in masks_l]
+                other_masks = [mask for mask in masks_s] + [mask for mask in masks_m]
+            else:
+                raise NotImplementedError
+            if not args.use_other_level:
+                other_masks = None
+
+        if now_frame == 0: # first frame
+            ann_obj_id_list = range(len(masks))
+
+            save_masks([masks[ann_obj_id]['segmentation'] for ann_obj_id in ann_obj_id_list],now_frame,os.path.join(base_dir,level,'mask_each_frame-sam1'))
+            
+            if os.getenv("ONLY_STATISTIC","f") == 't':
+                width = masks[0]['segmentation'].shape[1]
+                height = masks[0]['segmentation'].shape[0]
+                all_mask = np.zeros((height,width))
+                for ann_obj_id in ann_obj_id_list:
+                    all_mask = np.logical_or(all_mask,masks[ann_obj_id]['segmentation'])
+                
+                # import ipdb; ipdb.set_trace()
+                img = Image.fromarray((all_mask * 255).astype(np.uint8)).convert("RGB")
+                img.save(os.path.join(base_dir,level,'mask_each_frame-sam1','all.png'))
+                logger.info(f"num:{len(ann_obj_id_list)}")
+                logger.info(f"no mask ratio:{all_mask.sum()/(width*height)}")
+                exit()
+
+            for ann_obj_id in tqdm(ann_obj_id_list):
+                seg = masks[ann_obj_id]['segmentation']
+                prompts_loader.add(ann_obj_id,0,seg)
+
+        else:  
+            save_masks([mask['segmentation'] for mask in masks],now_frame,os.path.join(base_dir,level,'mask_each_frame-sam1'))
+            for id,mask in enumerate(masks_from_prev):
+                if mask.sum() == 0:
+                    continue
+                prompts_loader.add(id,now_frame,mask[0])
+            if is_key_frame:
+                new_mask_list = search_new_obj(masks_from_prev, masks, other_masks, mask_ratio_thresh)
+                logger.info(f"number of new obj: {len(new_mask_list)}")
+                
+                for i in range(len(new_mask_list)):
+                    new_mask = new_mask_list[i]['segmentation']
+                    prompts_loader.add(sum_id+i,now_frame,new_mask)
+
+        logger.info(f"obj num: {prompts_loader.get_obj_num()}")
+
+        
+        video_segments = get_video_segments(prompts_loader,predictor,inference_state, args.detect_stride, now_frame)
+        # video_segments contains the per-frame segmentation results
+        
+        vis_frame_stride = args.detect_stride
+        plt.close("all")
+        save_dir = os.path.join(base_dir,level,f"mask_each_frame_sam2")
+        os.makedirs(save_dir,exist_ok=True)
+        os.makedirs(os.path.join(save_dir,f"now_frame_{now_frame}"),exist_ok=True)
+
+        out_frame_idx = now_frame+vis_frame_stride
+        if out_frame_idx >= len(frame_names):
+            break
+        # 创建一个新的图形对象
+        fig, ax = plt.subplots(figsize=(6, 4))
+        ax.set_title(f"frame {out_frame_idx}")
+        
+        # 显示图像
+        img_path = os.path.join(video_dir, frame_names[out_frame_idx])
+        ax.imshow(Image.open(img_path))
+        # 显示分割掩码
+        out_mask_list = []
+        for out_obj_id, out_mask in video_segments[out_frame_idx].items():
+            idx_save_dir = os.path.join(save_dir,f"obj_{out_obj_id:02}")
+            # os.makedirs(idx_save_dir,exist_ok=True)
+            # import ipdb; ipdb.set_trace()
+            show_mask(out_mask, ax, obj_id=out_obj_id,random_color=False)
+            out_mask_list.append(out_mask)
+        
+        no_mask_ratio = cal_no_mask_area_ratio(out_mask_list)
+        if now_frame == 0:
+            mask_ratio_thresh = no_mask_ratio
+
+        save_masks(out_mask_list, out_frame_idx,os.path.join(save_dir,f"now_frame_{now_frame}"))
+        save_masks_npy(out_mask_list, out_frame_idx,os.path.join(save_dir,f"now_frame_{now_frame}"))
+        
+        # 保存图像
+        plt.savefig(os.path.join(save_dir, f"frame_{out_frame_idx}.png"))
+        
+        # 关闭当前图形对象，释放内存
+        plt.close(fig)
+        if no_mask_ratio > mask_ratio_thresh + 0.01:
+            masks_from_prev = out_mask_list
+            mask_ratio_thresh = no_mask_ratio
+            logger.info(f"mask_ratio_thresh: {mask_ratio_thresh}")
+            is_key_frame = True
+        else:
+            masks_from_prev = out_mask_list
+            is_key_frame = False
+            logger.info(f"mask_ratio_thresh: {mask_ratio_thresh}")
+
+
+    ###### Final output ######
+    save_dir = os.path.join(base_dir,level,"final-output")
+    video_segments = get_video_segments(prompts_loader,predictor,inference_state,args.detect_stride,0,final_output=True)
+    for out_frame_idx in tqdm(range(0, len(frame_names), 1)):
+        out_mask_list = []
+        for out_obj_id, out_mask in video_segments[out_frame_idx].items():
+            out_mask_list.append(out_mask)
+        
+        # 显示图像
+        img_path = os.path.join(video_dir, frame_names[out_frame_idx])
+        ax.imshow(Image.open(img_path))
+
+        no_mask_ratio = cal_no_mask_area_ratio(out_mask_list)
+        logger.info(no_mask_ratio)
+
+        save_masks(out_mask_list, out_frame_idx,save_dir)
+        save_masks_npy(out_mask_list, out_frame_idx,save_dir)
+    

--- a/readme.md
+++ b/readme.md
@@ -54,4 +54,6 @@ Please organize your video data as follows
 or you can use our demo datasets [chickenchicken](https://drive.google.com/file/d/10K_ePOMTjgQhWo1EXbM5aX7IU1EKvsrv/view?usp=sharing) and put it under `videos/chickenchicken`, then run
 ```bash
 bash scripts/chickenchicken.sh
+# or fast strategy
+bash scripts/chickenchicken_fast.sh
 ```

--- a/scripts/chickenchicken_fast.sh
+++ b/scripts/chickenchicken_fast.sh
@@ -1,0 +1,31 @@
+start_time=$(date +%s)
+
+for level in 'large'; do
+    echo $level
+
+    auto_mask_start_time=$(date +%s)
+    CUDA_VISIBLE_DEVICES=2 python auto-mask-fast.py \
+        --video_path videos/chickenchicken \
+        --output_dir output/chickenchicken \
+        --batch_size 40 \
+        --detect_stride 20 \
+        --level ${level}
+    auto_mask_end_time=$(date +%s)
+    auto_mask_elapsed_time=$((auto_mask_end_time - auto_mask_start_time))
+
+    visulization_start_time=$(date +%s)
+    CUDA_VISIBLE_DEVICES=2 python visulization.py \
+        --video_path videos/chickenchicken \
+        --output_dir output/chickenchicken \
+        --level ${level}
+    visulization_end_time=$(date +%s)
+    visulization_elapsed_time=$((visulization_end_time - visulization_start_time))
+
+    echo "auto-mask-batch.py execution time: ${auto_mask_elapsed_time} seconds"
+    echo "visulization.py execution time: ${visulization_elapsed_time} seconds"
+
+done
+
+end_time=$(date +%s)
+elapsed_time=$((end_time - start_time))
+echo "Total execution time: ${elapsed_time} seconds"

--- a/visulization.py
+++ b/visulization.py
@@ -7,154 +7,146 @@ import random
 import argparse
 import imageio
 
-
-def images_to_video(input_folder, output_video, fps=30,max_width=1920, max_height=1080):
+def images_to_video(input_folder, output_video, fps=30, max_width=1920, max_height=1080):
+    # Get all PNG images from the input folder and sort by filename (assumed to be frame numbers)
     images = [img for img in os.listdir(input_folder) if img.endswith(".png")]
-    images.sort(key=lambda x: int(os.path.splitext(x)[0]))  
+    images.sort(key=lambda x: int(os.path.splitext(x)[0]))
 
     if not images:
         print("No images found in the folder.")
         return
 
     frames = [imageio.imread(os.path.join(input_folder, img)) for img in images]
-    imageio.mimwrite(output_video, frames, fps=30)
-    
+    imageio.mimwrite(output_video, frames, fps=fps)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--video_path",type=str,required=True)
-    parser.add_argument("--output_dir",type=str,required=True)
-    parser.add_argument("--level",choices=['default','small','middle','large'])
+    # Video and output directory parameters
+    parser.add_argument("--video_path", type=str, required=False, 
+                        default="",
+                        help="Path to input images")
+    parser.add_argument("--output_dir", type=str, required=False, 
+                        default="",
+                        help="Output directory")
+    parser.add_argument("--level", choices=['default', 'small', 'middle', 'large'], default='large',
+                        help="Mask level")
+    # New parameter to choose visualization mode
+    parser.add_argument("--vis_mode", type=str, choices=["full", "seperate", "both"], default="full",
+                        help="Visualization mode: full (full-mask), seperate (separate masks per uid), both (generate both)")
     args = parser.parse_args()
 
     level = args.level
     basedir = args.output_dir
-    npybasedir = os.path.join(basedir,level,'final-output')
+    npybasedir = os.path.join(basedir, level, 'final-output')
     imagebasedir = args.video_path
-    savedir = os.path.join(basedir,level,'visualization','seperate')
-    os.makedirs(savedir,exist_ok=True)
+
+    # Load image and npy file lists
     image_name_list = os.listdir(imagebasedir)
-    image_name_list.sort()
+    image_name_list.sort(key=lambda p: int(os.path.splitext(p)[0]))
 
     npy_name_list = []
     for name in os.listdir(npybasedir):
         if 'npy' in name:
             npy_name_list.append(name)
     npy_name_list.sort()
-    print(npy_name_list)
-    npy_list = [np.load(os.path.join(npybasedir,name)) for name in npy_name_list]
-    image_list = [Image.open(os.path.join(imagebasedir,name)) for name in image_name_list]
+    print("Numpy files:", npy_name_list)
+    npy_list = [np.load(os.path.join(npybasedir, name)) for name in npy_name_list]
+    image_list = [Image.open(os.path.join(imagebasedir, name)) for name in image_name_list]
     assert len(npy_list) == len(image_name_list)
-    print(len(npy_list))
+    print("Number of frames:", len(npy_list))
 
+    # Create uid directories for separate visualization
     uid_dirs = {}
     for uid in range(npy_list[0].shape[0]):
-        uid_dir = os.path.join(savedir, f"uid_{uid}")
+        uid_dir = os.path.join(basedir, level, 'visualization', 'seperate', f"uid_{uid}")
         os.makedirs(uid_dir, exist_ok=True)
         uid_dirs[uid] = uid_dir
 
+    # Separate visualization: generate per-uid visualization and combined image per frame
+    if args.vis_mode in ["seperate", "both"]:
+        print("Generating separate visualization...")
+        # Loop over frames
+        for frame_id, (masks, image) in tqdm(enumerate(zip(npy_list, image_list)), total=len(npy_list)):
+            # Darken the original image for background
+            dark_image = ImageEnhance.Brightness(image).enhance(0.3)
+            dark_image_array = np.array(dark_image)
+            highlighted_images = []
+            mask_images = []
+            # Process each uid mask
+            for uid in range(masks.shape[0]):
+                current_mask = masks[uid][0]  # assuming first channel is used
+                image_array = np.array(image)
+                # Highlight current mask region by using the original image, others darkened
+                highlighted_image_array = np.where(current_mask[:, :, np.newaxis], image_array, dark_image_array)
+                highlighted_image = Image.fromarray(highlighted_image_array.astype('uint8'))
+                # Create a binary mask image for visualization
+                bool_mask_array = (current_mask * 255).astype(np.uint8)
+                bool_mask_image = Image.fromarray(bool_mask_array).convert("RGB")
+                # Create a combined image (original on top, mask below)
+                uid_frame = Image.new('RGB', (image.width, image.height * 2))
+                uid_frame.paste(highlighted_image, (0, 0))
+                uid_frame.paste(bool_mask_image, (0, image.height))
+                uid_frame.save(os.path.join(uid_dirs[uid], f"{frame_id:05}.png"))
+                highlighted_images.append(highlighted_image)
+                mask_images.append(bool_mask_image)
+            # Combine all uid visualizations side by side
+            total_width = image.width * len(highlighted_images)
+            max_height = image.height * 2
+            final_image = Image.new('RGB', (total_width, max_height))
+            for i, img in enumerate(highlighted_images):
+                final_image.paste(img, (i * image.width, 0))
+            for i, img in enumerate(mask_images):
+                final_image.paste(img, (i * image.width, image.height))
+            combined_save_path = os.path.join(basedir, level, 'visualization', 'seperate', f"{frame_id:05}.png")
+            final_image.save(combined_save_path)
+        # Optionally, generate separate videos for each uid from the separate visualization
+        output_video_dir = os.path.join(basedir, level, 'visualization', 'seperate', 'videos')
+        os.makedirs(output_video_dir, exist_ok=True)
+        for uid in tqdm(range(len(uid_dirs))):
+            uid_folder = uid_dirs[uid]
+            video_uid_path = os.path.join(output_video_dir, f"uid_{uid}.mp4")
+            images_to_video(uid_folder, video_uid_path)
 
-    for frame_id, (masks, image) in tqdm(enumerate(zip(npy_list,image_list))):
-        dark_image = ImageEnhance.Brightness(image).enhance(0.3)
-        dark_image_array = np.array(dark_image)
-        highlighted_images = []
-        mask_images = []
-        for uid in range(masks.shape[0]):
+    # Full mask visualization: blend original image with all masks colored
+    if args.vis_mode in ["full", "both"]:
+        print("Generating full mask visualization...")
+        savedir_full = os.path.join(basedir, level, 'visualization', 'full-mask-npy')
+        video_path = os.path.join(basedir, level, 'visualization', f'full-mask-{level}.mp4')
+        os.makedirs(savedir_full, exist_ok=True)
 
-            current_mask = masks[uid][0]
-            image_array = np.array(image)
+        # Define a helper function to generate random colors
+        def generate_random_colors(num_colors):
+            colors = []
+            for _ in range(num_colors):
+                color = tuple(random.randint(0, 255) for _ in range(3))
+                colors.append(color)
+            return colors
 
-            highlighted_image_array = np.where(current_mask[:, :, np.newaxis], image_array, dark_image_array)
-            highlighted_image = Image.fromarray(highlighted_image_array.astype('uint8'))
+        num_masks = max(len(masks) for masks in npy_list)
+        colors = generate_random_colors(num_masks)
 
-            bool_mask_array = (current_mask * 255).astype(np.uint8)
-            bool_mask_image = Image.fromarray(bool_mask_array).convert("RGB")
-
-            uid_frame = Image.new('RGB', (image.width, image.height * 2))
-            uid_frame.paste(highlighted_image, (0, 0))
-            uid_frame.paste(bool_mask_image, (0, image.height))
-            uid_frame.save(os.path.join(uid_dirs[uid], f"{frame_id:05}.png"))
-
-            highlighted_images.append(highlighted_image)
-            mask_images.append(bool_mask_image)
-
-        total_width = image.width * len(highlighted_images)
-        max_height = image.height * 2
-
-        final_image = Image.new('RGB', (total_width, max_height))
-
-        for i, img in enumerate(highlighted_images):
-            final_image.paste(img, (i * image.width, 0))
-
-        for i, img in enumerate(mask_images):
-            final_image.paste(img, (i * image.width, image.height))
-
-        final_image.save(os.path.join(savedir,f"{frame_id:05}.png"))
-
-    savedir = os.path.join(basedir,level,'visualization','full-mask-npy')
-    video_path = os.path.join(basedir,level,'visualization',f'full-mask-{level}.mp4')
-    os.makedirs(savedir,exist_ok=True)
-    image_name_list = os.listdir(imagebasedir)
-    image_name_list.sort()
-    print(image_name_list)
-    npy_name_list = []
-    for name in os.listdir(npybasedir):
-        if 'npy' in name:
-            npy_name_list.append(name)
-    npy_name_list.sort()
-    print(npy_name_list)
-    npy_list = [np.load(os.path.join(npybasedir,name)) for name in npy_name_list]
-    image_list = [Image.open(os.path.join(imagebasedir,name)) for name in image_name_list]
-
-    assert len(npy_list) == len(image_name_list)
-    print(len(npy_list))
-    # Generate a list of random colors
-    def generate_random_colors(num_colors):
-        colors = []
-        for _ in range(num_colors):
-            color = tuple(random.randint(0, 255) for _ in range(3))
-            colors.append(color)
-        return colors
-
-    num_masks = max(len(masks) for masks in npy_list)
-    colors = generate_random_colors(num_masks)
-
-    video_frames = []
-    output_path_list = []
-    for frame_id, (masks, image) in tqdm(enumerate(zip(npy_list, image_list))):
-        image_np = np.array(image)
-        mask_combined = np.zeros_like(image_np, dtype=np.uint8)
-
-        for i, mask in enumerate(masks):
-            color = colors[i % len(colors)]
-            # Ensure the mask is binary (0 or 1)
-            mask_binary = (mask[0] > 0).astype(np.uint8)
-            # Apply the mask color
-            for j in range(3):  # For each channel in RGB
-                mask_combined[:, :, j] += mask_binary * color[j]
-
-        # Blend the original image with the colored masks
-        mask_combined = np.clip(mask_combined, 0, 255)
-        blended_image = cv2.addWeighted(image_np, 0.7, mask_combined, 0.3, 0)
-
-        # Save each frame
-        output_path = os.path.join(savedir, f"frame_{frame_id:04d}.png")
-        output_path_list.append(output_path)
-
-        Image.fromarray(blended_image).save(output_path)
-        
-    # Generate the video
-
-    frames = [imageio.imread(img) for img in output_path_list]
-    imageio.mimwrite(video_path, frames, fps=30)
-
-    print(f"Video saved at {video_path}")
+        video_frames = []
+        output_path_list = []
+        for frame_id, (masks, image) in tqdm(enumerate(zip(npy_list, image_list)), total=len(npy_list)):
+            image_np = np.array(image)
+            mask_combined = np.zeros_like(image_np, dtype=np.uint8)
+            # Overlay each mask with its corresponding random color
+            for i, mask in enumerate(masks):
+                color = colors[i % len(colors)]
+                # Ensure the mask is binary (0 or 1)
+                mask_binary = (mask[0] > 0).astype(np.uint8)
+                for j in range(3):  # for each channel in RGB
+                    mask_combined[:, :, j] += mask_binary * color[j]
+            mask_combined = np.clip(mask_combined, 0, 255)
+            # Blend the original image with the colored mask
+            blended_image = cv2.addWeighted(image_np, 0.7, mask_combined, 0.3, 0)
+            output_path = os.path.join(savedir_full, f"frame_{frame_id:04d}.png")
+            output_path_list.append(output_path)
+            Image.fromarray(blended_image).save(output_path)
+        # Create video from generated images
+        frames = [imageio.imread(img) for img in output_path_list]
+        imageio.mimwrite(video_path, frames, fps=30)
+        print(f"Video saved at {video_path}")
 
 
-    output_video_dir = os.path.join(basedir,level,'visualization','seperate','videos')
-    os.makedirs(output_video_dir,exist_ok=True)
-
-    for uid in tqdm(range(len(uid_dirs))):
-        uid_folder = uid_dirs[uid]
-        images_to_video(uid_folder, os.path.join(output_video_dir,f"uid_{uid}.mp4"))


### PR DESCRIPTION
Dear Dr. Zhou,

Thank you for your excellent work! While using your repository, I noticed that auto-mask-batch.py takes a long time to run. Based on your code, I've optimized it by reducing the time complexity from O(n²/k) to O(n) while producing nearly identical outputs.

**Main Modifications:**

1. **Improved Efficiency of Video Segment Extraction**  
   - **Before:** The `get_video_segments` function would always propagate from the 0th frame when not producing final output, since it needed to save the subsequent frame masks for calculating the new `now_frame`.  
   - **After:** I added `step` and `start_frame_idx` parameters to `get_video_segments`, allowing propagation to start from a specified frame (`start_frame_idx`) and limiting the propagation length (`step`). For example, when computing `video_segments`, propagation now starts from the current frame (`now_frame`) and only moves forward by `args.detect_stride` frames instead of processing the entire video. This change significantly reduces the computational load for non-key frames, thus improving efficiency.

2. **Key Frame Selection Strategy Optimization**  
   - **Before:** After drawing the segmentation masks and computing the uncovered area ratio, the program would mark a frame as the new "reference frame" if the uncovered area exceeded a preset threshold. This required calculating the masks for subsequent frames, which was time-consuming.  
   - **After:** I introduced an `is_key_frame` flag. The initial frame (when `now_frame == 0`) is marked as a key frame by default. For subsequent frames, the decision to mark the next step frame as a key frame is based on a comparison between the uncovered area ratio (`no_mask_ratio`) and a threshold (`mask_ratio_thresh`). If `no_mask_ratio > mask_ratio_thresh + 0.01`, the next step frame is marked as a key frame (`is_key_frame = True`); otherwise, it remains non-key (`is_key_frame = False`).

3. **Optimized visulization.py**  
   - Added a new parameter `--vis_mode` with options: `full` (full-mask), `seperate` (per-uid separated masks), and `both` (generate both). Since generating per-uid masks can be time-consuming, this parameter allows users to flexibly choose the visualization mode to save time.

Thank you again for your outstanding work. I hope you consider merging my pull request or provide any feedback you may have.